### PR TITLE
[WIP] catching Signal::INT

### DIFF
--- a/src/icr.cr
+++ b/src/icr.cr
@@ -22,4 +22,8 @@ module Icr
   DELIMITER = "|||YIH22hSkVQN|||"
   CRYSTAL_COMMAND = "crystal"
   ROOT_PATH = File.expand_path("../..", __FILE__)
+
+  def self.handle_trap
+    puts "in trap"
+  end
 end

--- a/src/icr.cr
+++ b/src/icr.cr
@@ -22,8 +22,4 @@ module Icr
   DELIMITER = "|||YIH22hSkVQN|||"
   CRYSTAL_COMMAND = "crystal"
   ROOT_PATH = File.expand_path("../..", __FILE__)
-
-  def self.handle_trap
-    puts "in trap"
-  end
 end

--- a/src/icr/cli.cr
+++ b/src/icr/cli.cr
@@ -1,11 +1,5 @@
 require "option_parser"
 require "../icr"
-STDOUT.sync = true
-
-Signal::INT.trap {
-  Icr.handle_trap
-}
-
 
 is_debug = false
 libs = [] of String

--- a/src/icr/cli.cr
+++ b/src/icr/cli.cr
@@ -1,6 +1,10 @@
 require "option_parser"
 require "../icr"
 
+# Not 100% sure if we need this just yet
+STDIN.sync = true
+STDOUT.sync = true
+
 is_debug = false
 libs = [] of String
 

--- a/src/icr/cli.cr
+++ b/src/icr/cli.cr
@@ -1,5 +1,11 @@
 require "option_parser"
 require "../icr"
+STDOUT.sync = true
+
+Signal::INT.trap {
+  Icr.handle_trap
+}
+
 
 is_debug = false
 libs = [] of String

--- a/src/icr/command.cr
+++ b/src/icr/command.cr
@@ -4,6 +4,7 @@ module Icr
   #   * value - actual input
   #   * type - type of input(require, class, module, method, regular, etc)
   class Command
+    DELIMITER = "|||DFG4tDS4a0|||"
     getter :type, :value
 
     def initialize(@type : Symbol, @value : String)
@@ -11,7 +12,7 @@ module Icr
 
     # returns `String` of the state the `@value` is in. "ok" or "err"
     def state
-      value.split(Icr::DELIMITER)[1]
+      @value.split(DELIMITER)[1]
     end
   end
 end

--- a/src/icr/command.cr
+++ b/src/icr/command.cr
@@ -8,5 +8,10 @@ module Icr
 
     def initialize(@type : Symbol, @value : String)
     end
+
+    # returns `String` of the state the `@value` is in. "ok" or "err"
+    def state
+      value.split(Icr::DELIMITER)[1]
+    end
   end
 end

--- a/src/icr/command_stack.cr
+++ b/src/icr/command_stack.cr
@@ -57,6 +57,19 @@ module Icr
       code.strip
     end
 
+    # returns `Array(String)` of the raw `Command` values
+    def lines
+      commands.map(&.value)
+    end
+
+    # returns `self`. Removes all values from the end of @commands where the state is `:err`.
+    def reset!
+      new_stack = commands.dup
+      commands.reverse.each { |c| c.state == "err" ? new_stack.pop : break }
+      @commands = new_stack
+      self
+    end
+
     private def code(command_type, indent_level = 0)
       cmds = @commands.select { |cmd| cmd.type == command_type }.map &.value
       cmds.map { |cmd| ("  " * indent_level) + cmd }.join("\n")

--- a/src/icr/command_stack.cr
+++ b/src/icr/command_stack.cr
@@ -64,8 +64,13 @@ module Icr
 
     # returns `self`. Removes all values from the end of @commands where the state is `:err`.
     def reset!
+      puts "RESETTING"
       new_stack = commands.dup
-      commands.reverse.each { |c| c.state == "err" ? new_stack.pop : break }
+      commands.reverse.each do |c| 
+        if c.state == "err"
+          new_stack.pop
+        end
+      end
       @commands = new_stack
       self
     end

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -92,10 +92,7 @@ module Icr
 
     private def ask_for_input(level = 0)
       invitation = default_invitation + "  " * level
-      # This seems to block the event loop causing delays in trapping the signal
-      #Readline.readline(invitation, true)
-      print invitation
-      gets
+      Readline.readline(invitation, true)
     end
 
     private def get_crystal_version!

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -14,6 +14,7 @@ module Icr
     end
 
     def start(code : String)
+      enable_signal_trap
       process_input(code) unless code.empty?
       loop do
         input = ask_for_input
@@ -21,11 +22,20 @@ module Icr
       end
     end
 
+    private def enable_signal_trap
+      STDOUT.sync = true
+      Signal::INT.trap {
+        puts "\n\n#{@command_stack.to_code}\n\n"
+      }
+    end
+
     private def process_input(input)
       if input.nil?
-        # Ctrl+D was pressed, print new line before exit
+        puts "no input"
+        # Need to determine between ^C and ^D
+        # if ^D then exit
+        # if ^C then reset to clean status
         puts
-        __exit__
       elsif %w(exit quit).includes?(input.to_s.strip)
         __exit__
       elsif input.to_s.strip != ""

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -23,19 +23,17 @@ module Icr
     end
 
     private def enable_signal_trap
-      STDOUT.sync = true
       Signal::INT.trap {
-        puts "\n\n#{@command_stack.to_code}\n\n"
+        puts
+        # reset @command_stack to last known clean state
       }
     end
 
     private def process_input(input)
       if input.nil?
-        puts "no input"
-        # Need to determine between ^C and ^D
-        # if ^D then exit
-        # if ^C then reset to clean status
+        # ^D was called. Exit
         puts
+        __exit__
       elsif %w(exit quit).includes?(input.to_s.strip)
         __exit__
       elsif input.to_s.strip != ""
@@ -94,7 +92,10 @@ module Icr
 
     private def ask_for_input(level = 0)
       invitation = default_invitation + "  " * level
-      Readline.readline(invitation, true)
+      # This seems to block the event loop causing delays in trapping the signal
+      #Readline.readline(invitation, true)
+      print invitation
+      gets
     end
 
     private def get_crystal_version!

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -24,8 +24,8 @@ module Icr
 
     private def enable_signal_trap
       Signal::INT.trap {
-        puts
-        # reset @command_stack to last known clean state
+        @command_stack.reset!
+        puts  
       }
     end
 
@@ -49,7 +49,7 @@ module Icr
     private def process_result(result : SyntaxCheckResult, command : String)
       case result.status
       when :ok
-        @command_stack.push(command)
+        @command_stack.push(command + " ##{Icr::DELIMITER}ok")
         execute
       when :unexpected_eof, :unterminated_literal
         # If syntax is invalid because of unexpected EOF, or
@@ -59,7 +59,7 @@ module Icr
         process_command(new_command)
       when :error
         # Give it the second try, validate the command in scope of entire file
-        @command_stack.push(command)
+        @command_stack.push(command + " ##{Icr::DELIMITER}err")
         entire_file_result = check_syntax(@command_stack.to_code)
         case entire_file_result.status
         when :ok

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -48,7 +48,7 @@ module Icr
     private def process_result(result : SyntaxCheckResult, command : String)
       case result.status
       when :ok
-        @command_stack.push(command + " ##{Icr::DELIMITER}ok")
+        @command_stack.push(command + " ##{Command::DELIMITER}ok")
         execute
       when :unexpected_eof, :unterminated_literal
         # If syntax is invalid because of unexpected EOF, or
@@ -58,7 +58,7 @@ module Icr
         process_command(new_command)
       when :error
         # Give it the second try, validate the command in scope of entire file
-        @command_stack.push(command + " ##{Icr::DELIMITER}err")
+        @command_stack.push(command + " ##{Command::DELIMITER}err")
         entire_file_result = check_syntax(@command_stack.to_code)
         case entire_file_result.status
         when :ok

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -25,7 +25,6 @@ module Icr
     private def enable_signal_trap
       Signal::INT.trap {
         @command_stack.reset!
-        puts  
       }
     end
 


### PR DESCRIPTION
This PR isn't ready yet, but as an initial start I wanted to get your thoughts and input on some stuff.

Before this, ^C and ^D were caught by the same `process_input` which would just exit the console. Now, ^D will exit (just like IRB), but ^C is caught. The next step will be to create a state, and manage the state of the input. Then using ^C to reset the state to the last known clean state.

Related: #33