### PR TITLE
Add --no-debug flag to improve speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ICR_BIN ?= $(shell which icr)
 PREFIX ?= /usr/local
 
 build:
-	$(CRYSTAL_BIN) build --release -o bin/icr src/icr/cli.cr $(CRFLAGS)
+	$(CRYSTAL_BIN) build --release --no-debug -o bin/icr src/icr/cli.cr $(CRFLAGS)
 clean:
 	rm -f ./bin/icr
 test: build

--- a/src/icr/executer.cr
+++ b/src/icr/executer.cr
@@ -18,7 +18,7 @@ module Icr
       File.write(@tmp_file_path, @command_stack.to_code)
       io_out = IO::Memory.new
       io_error = IO::Memory.new
-      command = "#{CRYSTAL_COMMAND} #{@tmp_file_path}"
+      command = "#{CRYSTAL_COMMAND} #{@tmp_file_path} --no-debug"
       status = Process.run(command, nil, nil, false, true, nil, io_out, io_error)
       print_source_file if @debug
 


### PR DESCRIPTION
Avoiding debugging info with `--no-debug` flag, improves compilation speed.

```
>>> time crystal hi.cr --no-debug
Hi ICR!

real    0m2.068s
user    0m2.327s
sys     0m0.300s
>>> time crystal hi.cr
Hi ICR!

real    0m2.270s
user    0m2.650s
sys     0m0.320s
```

Is about 200 ms faster with `--no-debug` flag
