### PR TITLE
catch constant assignment and set it outside of the exec method. fixes #51

### DIFF
--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -246,6 +246,7 @@ describe "icr command" do
       HTTP_STATUS    =    404
       Constant = "cheese"
       ISO8859_1 = :latin 
+      A =~ /test/
       CRYSTAL
       icr(input).should_not match /dynamic\sconstant/
     end
@@ -257,6 +258,14 @@ describe "icr command" do
       A == B
       CRYSTAL
       icr(input).should match /false/
+    end
+
+    it "still throws dynamic constant assignment errors when needed" do
+      input = <<-CRYSTAL
+      def test
+        A = 1
+      CRYSTAL
+      icr(input).should match /dynamic\sconstant\sassignment/
     end
   end
   it "allows for macros" do

--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -237,4 +237,11 @@ describe "icr command" do
     CRYSTAL
     icr(input).should match /45/
   end
+
+  it "allows for constant assignment" do
+    input = <<-CRYSTAL
+    A = 0
+    CRYSTAL
+    icr(input).should_not match /dynamic\sconstant/
+  end
 end

--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -242,6 +242,10 @@ describe "icr command" do
     it "allows for constant assignment" do
       input = <<-CRYSTAL
       A = 0
+      B=1
+      HTTP_STATUS    =    404
+      Constant = "cheese"
+      ISO8859_1 = :latin 
       CRYSTAL
       icr(input).should_not match /dynamic\sconstant/
     end

--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -238,10 +238,21 @@ describe "icr command" do
     icr(input).should match /45/
   end
 
-  it "allows for constant assignment" do
-    input = <<-CRYSTAL
-    A = 0
-    CRYSTAL
-    icr(input).should_not match /dynamic\sconstant/
+  describe "using constants" do
+    it "allows for constant assignment" do
+      input = <<-CRYSTAL
+      A = 0
+      CRYSTAL
+      icr(input).should_not match /dynamic\sconstant/
+    end
+
+    it "still allows for checking constant equality" do
+      input = <<-CRYSTAL
+      A = 0
+      B = 1
+      A == B
+      CRYSTAL
+      icr(input).should match /false/
+    end
   end
 end

--- a/src/icr/command_stack.cr
+++ b/src/icr/command_stack.cr
@@ -25,7 +25,7 @@ module Icr
         type = :struct
       elsif command.strip =~ /^alias\s/
         type = :alias
-      elsif command.strip =~ /^[A-Z]+([a-z_0-9].+)?\s*\={1}[^=]/
+      elsif command.strip =~ /^[A-Z]+([a-z_0-9].+)?\s*\={1}[^=~]/
         type = :constant_assignment
       elsif command.strip =~ /^macro\s/
         type = :macro

--- a/src/icr/command_stack.cr
+++ b/src/icr/command_stack.cr
@@ -25,7 +25,7 @@ module Icr
         type = :struct
       elsif command.strip =~ /^alias\s/
         type = :alias
-      elsif command.strip =~ /^[A-Z_]+\s*\=/
+      elsif command.strip =~ /^[A-Z_]+\s*\={1}[^=]/
         type = :constant_assignment
       else
         type = :regular

--- a/src/icr/command_stack.cr
+++ b/src/icr/command_stack.cr
@@ -25,6 +25,8 @@ module Icr
         type = :struct
       elsif command.strip =~ /^alias\s/
         type = :alias
+      elsif command.strip =~ /^[A-Z_]+\s*\=/
+        type = :constant_assignment
       else
         type = :regular
       end
@@ -47,6 +49,7 @@ module Icr
         #{code(:record)}
         #{code(:struct)}
         #{code(:alias)}
+        #{code(:constant_assignment)}
 
         def __icr_exec__
         #{code(:regular, 1)}

--- a/src/icr/command_stack.cr
+++ b/src/icr/command_stack.cr
@@ -25,7 +25,7 @@ module Icr
         type = :struct
       elsif command.strip =~ /^alias\s/
         type = :alias
-      elsif command.strip =~ /^[A-Z_]+\s*\={1}[^=]/
+      elsif command.strip =~ /^[A-Z]+([a-z_0-9].+)?\s*\={1}[^=]/
         type = :constant_assignment
       else
         type = :regular


### PR DESCRIPTION
This PR catches assignments to constants like

```ruby
A = 0
B=1
HTTP_STATUS      =    404
```

But it will still ignore constant usages like `IO::Memory.new` or `String.build`. This will also ignore when checking equality between 2 constants like `A == B`.