### PR TITLE
Remove post-install script

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,3 @@ authors:
   - Potapov Sergey <blake131313@gmail.com>
 
 license: MIT
-
-scripts:
-  postinstall: make install


### PR DESCRIPTION
ICR is used as dependency on other shards, it allow to install without post-install issues.

```
$ amber new blog --template ecr --database sqlite --deps
...
Installing icr (0.3.0)
Postinstall make install
Failed make install:
/usr/bin/crystal build --release --no-debug -o bin/icr src/icr/cli.cr
mkdir -p /usr/local/bin
cp ./bin/icr /usr/local/bin
cp: cannot create regular file '/usr/local/bin/icr': Permission denied
make: *** [Makefile:13: install] Error 1
```

Also see: https://travis-ci.org/amberframework/amberframework.org/builds/294059765?utm_source=github_status&utm_medium=notification
