### PR TITLE
Some small grammar fixes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can require local files by relative path (starts with `./`):
 require "./src/my_cool_lib"
 ```
 
-Libs can also be required from the cli
+Libs can also be required from the cli:
 
 ```
 $ icr -r colorize -r ./src/my_cool_lib
@@ -75,9 +75,9 @@ Arch Linux users can install ICR [from AUR](https://aur.archlinux.org/packages/c
 
 
 ## How does it work?
-* Every time you press `Enter` it adds new instruction, generates new crystal program and executes it.
-* The output is split into 2 parts: regular program output (e.g. output from `puts 10`) and value returned by the last command
-* The regular output is saved, and when you type a new instruction, new program is generated. The saved output is subtracted from the new output, and the difference is printed out. It makes an illusion that only new instructions are executed :)
+* Every time you press `Enter` it adds a new instruction, generates a new crystal program, and executes it.
+* The output is split into 2 parts: regular program output (e.g. output from `puts 10`) and the value returned by the last command.
+* The regular output is saved, and when you type a new instruction, a new program is generated. The saved output is subtracted from the new output, and the difference is printed out. It creates an illusion that only new instructions are executed :)
 
 ## Commands and special locals
 


### PR DESCRIPTION
The word 'a' was missing in a few sentences in the README.