### PR TITLE
Reset ICR

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Arch Linux users can install ICR [from AUR](https://aur.archlinux.org/packages/c
 * `paste` - enables paste mode
 * `debug` - toggles debug mode off and on. In debug mode icr will print the code before executing it.
 * `quit` or `exit` - exits current interactive console
+* `reset` - clear out all of the accumulated commands. 
 * `__` - holds the result of the last expression. Example:
 
 ```crystal

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Arch Linux users can install ICR [from AUR](https://aur.archlinux.org/packages/c
 ## Commands and special locals
 
 * `paste` - enables paste mode
+* `debug` - toggles debug mode off and on. In debug mode icr will print the code before executing it.
 * `quit` or `exit` - exits current interactive console
 * `__` - holds the result of the last expression. Example:
 

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -3,7 +3,7 @@ module Icr
   class Console
     @crystal_version : String?
 
-    def initialize(@debug = false)
+    def initialize(debug = false)
       @command_stack = CommandStack.new
       @executer = Executer.new(@command_stack, debug)
       @crystal_version = get_crystal_version!
@@ -30,6 +30,9 @@ module Icr
         __exit__
       elsif input.to_s.strip == "paste"
         paste_mode()
+      elsif input.to_s.strip == "debug"
+        @executer.debug = !@executer.debug
+        puts "Debug: #{@executer.debug}"
       elsif input.to_s.strip != ""
         process_command(input.to_s)
       end

--- a/src/icr/executer.cr
+++ b/src/icr/executer.cr
@@ -2,6 +2,8 @@ module Icr
   # Build crystal source code file based on commands in CommandStack, executes it
   # as crystal program and returns result as an instance of ExecutionResult.
   class Executer
+    property debug
+
     def initialize(@command_stack : CommandStack, @debug = false)
       # Temporary file where generated source code is written
       # NOTE: File is created in the current dir, in order to be able to


### PR DESCRIPTION
This patch adds a new command 'reset' to icr that clears out the command stack. Just quicker than restarting the whole program.