### PR TITLE
Use `shards build` in the `build` step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@
 /bin/icr
 src/bin
 
+/bin/*.dwarf
+
 .icr.*.cr

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ICR_BIN ?= $(shell which icr)
 PREFIX ?= /usr/local
 
 build:
-	$(SHARDS_BIN) --production build $(CRFLAGS)
+	$(SHARDS_BIN) build --release $(CRFLAGS)
 clean:
 	rm -f ./bin/icr ./bin/icr.dwarf
 test: build

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 CRYSTAL_BIN ?= $(shell which crystal)
+SHARDS_BIN ?= $(shell which shards)
 ICR_BIN ?= $(shell which icr)
 PREFIX ?= /usr/local
 
 build:
-	$(CRYSTAL_BIN) build --release --no-debug -o bin/icr src/icr/cli.cr $(CRFLAGS)
+	$(SHARDS_BIN) --production build $(CRFLAGS)
 clean:
-	rm -f ./bin/icr
+	rm -f ./bin/icr ./bin/icr.dwarf
 test: build
 	$(CRYSTAL_BIN) spec
 install: build

--- a/shard.yml
+++ b/shard.yml
@@ -6,6 +6,6 @@ authors:
 
 targets:
   icr:
-    main: src/icr.cr
+    main: src/icr/cli.cr
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -4,4 +4,8 @@ version: 0.5.0
 authors:
   - Potapov Sergey <blake131313@gmail.com>
 
+targets:
+  icr:
+    main: src/icr.cr
+
 license: MIT


### PR DESCRIPTION
Now that the [`shard.yml` SPEC][spec] supports specifying targets, it makes sense to implement the `build` target in the `Makefile` in terms of that.

[spec]: https://github.com/crystal-lang/shards/blob/master/SPEC.md