### PR TITLE
Add --prompt-mode flag

### DIFF
--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -14,6 +14,26 @@ describe "icr command" do
       icr("", "-h").should contain("Usage: icr [options]")
     end
 
+    describe "--prompt-mode option" do
+      it "allows to change to simple prompt mode" do
+        icr("1", "--prompt-mode", "simple", "--no-color").should match /> 1/
+      end
+
+      it "allows to change to none prompt mode" do
+        icr("1", "--prompt-mode", "none", "--no-color").should match /1/
+      end
+
+      it "allows to change to default prompt mode" do
+        icr("1", "--prompt-mode", "default", "--no-color").should match /> 1/
+      end
+
+      it "raises argument error if prompt mode is wrong" do
+        expect_raises(ArgumentError) do
+          Icr::Console.new(prompt_mode: "no-such-mode").start
+        end
+      end
+    end
+
     describe "using the -r option" do
       it "requires the colorize lib" do
         input = <<-CODE

--- a/src/icr/cli.cr
+++ b/src/icr/cli.cr
@@ -12,6 +12,7 @@ UPDATE_CHECK_DISABLED  = "#{CONFIG_HOME}/update_check_disabled"
 UPDATE_CHECK_FILE      = "#{CONFIG_HOME}/update_check.yml"
 
 is_debug = false
+prompt_mode = "default"
 libs = [] of String
 usage_warning_accepted = File.exists? USAGE_WARNING_ACCEPTED
 update_check_disabled = File.exists? UPDATE_CHECK_DISABLED
@@ -89,6 +90,12 @@ OptionParser.parse! do |parser|
     libs.push(%{require "#{filename}"})
   end
 
+  parser.on("-p PROMPT", "--prompt-mode=PROMPT", "Switch prompt mode. \
+            Pre-defined prompt modes are `default`, `simple` and `none`"
+  ) do |mode|
+    prompt_mode = mode.downcase
+  end
+
   parser.on("--disable-usage-warning", "Disable usage warning") do
     Dir.mkdir_p CONFIG_HOME
     File.touch USAGE_WARNING_ACCEPTED
@@ -116,4 +123,4 @@ print_usage_warning unless usage_warning_accepted
 check_for_update unless update_check_disabled
 
 code = libs.join(";")
-Icr::Console.new(is_debug).start(code)
+Icr::Console.new(debug: is_debug, prompt_mode: prompt_mode).start(code)

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -3,7 +3,7 @@ module Icr
   class Console
     @crystal_version : String?
 
-    def initialize(debug = false)
+    def initialize(debug = false, @prompt_mode = "default")
       @command_stack = CommandStack.new
       @executer = Executer.new(@command_stack, debug)
       @crystal_version = get_crystal_version!
@@ -83,7 +83,7 @@ module Icr
           # Move the cursor at the first line of command
           command.lines.size.times { STDOUT << "\e[A\e[K" }
 
-          STDOUT << Highlighter.new(default_invitation).highlight(command)
+          STDOUT << Highlighter.new(prompt).highlight(command)
         end
 
         execute
@@ -132,7 +132,7 @@ module Icr
     end
 
     private def ask_for_input(level = 0)
-      invitation = default_invitation + "  " * level
+      invitation = prompt + "  " * level
       Readline.readline(invitation, true)
     end
 
@@ -147,8 +147,17 @@ module Icr
       match && match[0]?
     end
 
-    private def default_invitation
-      "icr(#{@crystal_version}) > "
+    private def prompt
+      case @prompt_mode
+      when "default"
+        "icr(#{@crystal_version}) > "
+      when "simple"
+        "> "
+      when "none"
+        ""
+      else
+        raise ArgumentError.new "wrong prompt mode"
+      end
     end
 
     private def print_execution_result?


### PR DESCRIPTION
fixes #96

```
$ ./bin/icr
icr(0.24.2) >
icr(0.24.2) > ^D

$ ./bin/icr --prompt-mode simple
> a = 1
 => 1
> ^D

$ ./bin/icr --prompt-mode none
a = 1
 => 1
^D

$ ./bin/icr --prompt-mode no-such-mode
wrong prompt mode (ArgumentError)
  from Icr::Console#prompt:String
  from __crystal_main
  from main

```

/cc @KINGSABRI 