### PR TITLE
Remove 'tempfile'

### DIFF
--- a/src/icr.cr
+++ b/src/icr.cr
@@ -1,5 +1,4 @@
 require "readline"
-require "tempfile"
 require "io/memory"
 require "random/secure"
 require "colorize"


### PR DESCRIPTION
'tempfile' is no longer 'require'd.

It appears that 'tempfile' is either required by default or part of Crystal 0.27 core.  Removing the 'require' results in a successful compile and a working `icr`.