### PR TITLE
Quote the File Path

### DIFF
--- a/src/icr/executer.cr
+++ b/src/icr/executer.cr
@@ -20,7 +20,7 @@ module Icr
       File.write(@tmp_file_path, @command_stack.to_code)
       io_out = IO::Memory.new
       io_error = IO::Memory.new
-      command = "#{CRYSTAL_COMMAND} #{@tmp_file_path} --no-debug"
+      command = "#{CRYSTAL_COMMAND} \"#{@tmp_file_path}\" --no-debug"
       status = Process.run(command, shell: true, output: io_out, error: io_error)
       print_source_file if @debug
 


### PR DESCRIPTION
Quote the file path so that spaces in the path don't break the command passed to the shell.
