### PR TITLE
Expand tilde in config path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /doc/
 /libs/
+/lib/
 /.crystal/
 /.shards/
 

--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -37,7 +37,7 @@ describe "icr command" do
 
     describe "custom directory" do
       it "allows to run within a directory with spaces" do
-        within_temp_folder("./foo\ bar") do
+        within_temp_folder do
           input = <<-CODE
             a = "baz"
             __

--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -412,4 +412,21 @@ describe "icr command" do
       icr("1 + 2").should contain("\e[0;34m1\e[0;m \e[0;37m+\e[0;m \e[0;34m2\e[0;m")
     end
   end
+
+  describe "configuration directory" do
+    it "creates update_check.yml" do
+      path = Path[Dir.tempdir].join("xdg_spec").to_s
+      icr("", {"XDG_CONFIG_HOME" => path})
+      File.exists?(Path[path].join("icr/update_check.yml").to_s).should be_true
+      FileUtils.rm_r path if Dir.exists?(path)
+    end
+
+    it "expands tilde to $HOME" do
+      path = "~/.tmp/xdg_spec"
+      abs_path = path.gsub("~", Path.home.to_s)
+      icr("", {"XDG_CONFIG_HOME" => path})
+      Dir.exists?(abs_path).should be_true
+      FileUtils.rm_r abs_path if Dir.exists?(abs_path)
+    end
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -19,10 +19,12 @@ def icr(input : String, *args : String, env = nil)
   io_out.to_s.strip
 end
 
-def within_temp_folder(path : String)
+def within_temp_folder(path : String = File.tempname)
+  pwd = FileUtils.pwd
   FileUtils.mkdir_p path
   FileUtils.cd path
   yield
 ensure
+  FileUtils.cd pwd unless pwd.nil?
   FileUtils.rm_r path if Dir.exists?(path)
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,12 +2,12 @@ require "spec"
 require "../src/icr"
 
 # Execute icr command with the given input and return stripped output.
-def icr(input : String)
-  icr(input, "")
+def icr(input : String, env : Hash(String, String) | Nil = nil)
+  icr(input, "", env: env)
 end
 
 # Optionally, you can pass flags to the icr command
-def icr(input : String, *args)
+def icr(input : String, *args : String, env = nil)
   cmd = ["#{Icr::ROOT_PATH}/bin/icr"]
   cmd.push(*args) unless args.empty?
 
@@ -15,7 +15,7 @@ def icr(input : String, *args)
   io_out = IO::Memory.new
   io_error = IO::Memory.new
 
-  Process.run(cmd.join(" "), nil, nil, false, true, io_in, io_out, io_error)
+  Process.run(cmd.join(" "), nil, env, false, true, io_in, io_out, io_error)
   io_out.to_s.strip
 end
 

--- a/src/icr/cli.cr
+++ b/src/icr/cli.cr
@@ -6,7 +6,7 @@ require "yaml"
 require "../icr"
 
 XDG_CONFIG_HOME        = ENV.fetch("XDG_CONFIG_HOME", "~/.config")
-CONFIG_HOME            = File.expand_path "#{XDG_CONFIG_HOME}/icr"
+CONFIG_HOME            = File.expand_path "#{XDG_CONFIG_HOME}/icr", home: true
 USAGE_WARNING_ACCEPTED = "#{CONFIG_HOME}/usage_warning_accepted"
 UPDATE_CHECK_DISABLED  = "#{CONFIG_HOME}/update_check_disabled"
 UPDATE_CHECK_FILE      = "#{CONFIG_HOME}/update_check.yml"


### PR DESCRIPTION
In Crystal 0.32.0, File.expand_path was changed to no longer expand the tilde (\~) character by default. This causes icr to create a '~' directory in the current folder.

This change restores the old behavior by setting home: true.

Also includes a commit that adds /lib directory to gitignore.