### PR TITLE
add #help comment, fix #122

### DIFF
--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -184,7 +184,6 @@ module Icr
         puts result.error_output
 
         puts if Colorize.enabled?
-        master
       end
     end
 

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -84,6 +84,15 @@ module Icr
       elsif input.to_s.strip == "#debug"
         @executer.debug = !@executer.debug
         puts "Debug: #{@executer.debug}"
+      elsif input.to_s.strip == "#help"
+        puts <<-EOF
+        All commands:
+         #exit, #quit      Exit ICR.
+         #paste            Enter paste mode.
+         #reset            Reset the environment.
+         #debug            Enter debug mode.
+         #help             Print this message.
+        EOF
       elsif input.to_s.strip != ""
         process_command(input.to_s)
       end
@@ -173,6 +182,7 @@ module Icr
         end
       else
         puts result.error_output
+        puts
       end
     end
 


### PR DESCRIPTION
This PR adds a magic #help comment that prints out every magic comment and what it does, and fixes a minor bug in the way errors are printed. The spec was not updated for the #help comment, since I assume the help message is subject to change.