### PR TITLE
fix output on error

### DIFF
--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -173,6 +173,7 @@ module Icr
         end
       else
         puts result.error_output
+        puts if Colorize.enabled?
       end
     end
 


### PR DESCRIPTION
Currently on error output is wrong:

![Peek 2021-03-16 11-36](https://user-images.githubusercontent.com/61285/111288562-f91d1000-864c-11eb-8d21-a5510bca3c4c.gif)

With `--no-color` option everything is fine.

After fix:

![Peek 2021-03-16 11-47](https://user-images.githubusercontent.com/61285/111289167-8eb89f80-864d-11eb-8918-763dd5b65b8e.gif)
