### PR TITLE
Upgrade Crystal version in shard.yml to allow >= 0.33.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: icr
 version: 0.8.0
 
-crystal: 0.33.0
+crystal: ">= 0.33.0"
 
 dependencies:
   readline:


### PR DESCRIPTION
* Allowing from Crystal v0.33.0 to retain support as is.
* Attempted to run the built for this branch using Crystal v1.0.0 and the build is green.

![image](https://user-images.githubusercontent.com/84005/126633110-587b9ba9-de45-45a3-9a2c-7df73d1810c6.png)
